### PR TITLE
Add initial terraform code for bcrypt hash check

### DIFF
--- a/groups/hash-check/hash-check/lambda.tf
+++ b/groups/hash-check/hash-check/lambda.tf
@@ -1,0 +1,52 @@
+locals {
+  lambda_function_name = "${var.service}-${var.environment}"
+}
+
+resource "aws_lambda_function" "hash_check" {
+  depends_on = [aws_cloudwatch_log_group.hash_check]
+
+  function_name = local.lambda_function_name
+  s3_bucket     = var.release_bucket_name
+  s3_key        = var.release_artifact_key
+  role          = aws_iam_role.lambda_execution.arn
+  handler       = var.lambda_handler_name
+  memory_size   = var.lambda_memory_size
+  timeout       = var.lambda_timeout_seconds
+  runtime       = var.lambda_runtime
+
+  tags = {
+    Name        = local.lambda_function_name
+    Environment = var.environment
+    Service     = var.service
+  }
+}
+
+resource "aws_cloudwatch_log_group" "hash_check" {
+  name              = "/aws/lambda/${local.lambda_function_name}"
+  retention_in_days = var.lambda_logs_retention_days
+}
+
+resource "aws_iam_role" "lambda_execution" {
+  name               = "${var.service}-${var.environment}-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_trust.json
+}
+
+data "aws_iam_policy_document" "lambda_trust" {
+  statement {
+    sid = "LambdaCanAssumeThisRole"
+
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "lambda.amazonaws.com"
+      ]
+    }
+  }
+}

--- a/groups/hash-check/hash-check/variables.tf
+++ b/groups/hash-check/hash-check/variables.tf
@@ -1,0 +1,64 @@
+variable "aws_account" {
+  type        = string
+  description = "The AWS account name"
+}
+
+variable "aws_account_id" {
+  type        = string
+  description = "The AWS account identifier"
+}
+
+variable "aws_profile" {
+  type        = string
+  description = "The AWS profile name; used as a prefix for Vault secrets"
+}
+
+variable "region" {
+  type        = string
+  description = "The AWS region in which resources will be created"
+}
+
+variable "environment" {
+  type        = string
+  description = "The environment name to be used when creating AWS resources"
+}
+
+variable "service" {
+  type        = string
+  description = "The service name to be used when creating AWS resources"
+}
+
+variable "lambda_handler_name" {
+  type        = string
+  description = "The lambda function entrypoint"
+}
+
+variable "lambda_logs_retention_days" {
+  type        = number
+  description = "The number of days to retain Lambda logs in CloudWatch"
+}
+
+variable "lambda_memory_size" {
+  type        = string
+  description = "The amount of memory made available to the Lambda function at runtime in megabytes"
+}
+
+variable "lambda_timeout_seconds" {
+  type        = string
+  description = "The amount of time the lambda function is allowed to run before being stopped"
+}
+
+variable "lambda_runtime" {
+  type        = string
+  description = "The lambda runtime to use for the function"
+}
+
+variable "release_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket containing the release artefact for the Lambda function"
+}
+
+variable "release_artifact_key" {
+  type        = string
+  description = "The release artifact key for the Lambda function"
+}

--- a/groups/hash-check/hash-check/variables.tf
+++ b/groups/hash-check/hash-check/variables.tf
@@ -1,18 +1,3 @@
-variable "aws_account" {
-  type        = string
-  description = "The AWS account name"
-}
-
-variable "aws_account_id" {
-  type        = string
-  description = "The AWS account identifier"
-}
-
-variable "aws_profile" {
-  type        = string
-  description = "The AWS profile name; used as a prefix for Vault secrets"
-}
-
 variable "region" {
   type        = string
   description = "The AWS region in which resources will be created"

--- a/groups/hash-check/hash-check/variables.tf
+++ b/groups/hash-check/hash-check/variables.tf
@@ -1,8 +1,3 @@
-variable "region" {
-  type        = string
-  description = "The AWS region in which resources will be created"
-}
-
 variable "environment" {
   type        = string
   description = "The environment name to be used when creating AWS resources"

--- a/groups/hash-check/main.tf
+++ b/groups/hash-check/main.tf
@@ -4,29 +4,14 @@ provider "aws" {
   version = "~> 2.50.0"
 }
 
-provider "vault" {
-  auth_login {
-    path = "auth/userpass/login/${var.vault_username}"
-
-    parameters = {
-      password = var.vault_password
-    }
-  }
-}
-
 terraform {
   backend "s3" {
   }
 }
 
-data "aws_caller_identity" "current" {}
-
 module "hash_check" {
   source = "./hash-check"
 
-  aws_account                           = var.aws_account
-  aws_account_id                        = data.aws_caller_identity.current.account_id
-  aws_profile                           = var.aws_profile
   environment                           = var.environment
   lambda_handler_name                   = var.lambda_handler_name
   lambda_logs_retention_days            = var.lambda_logs_retention_days

--- a/groups/hash-check/main.tf
+++ b/groups/hash-check/main.tf
@@ -1,0 +1,40 @@
+
+provider "aws" {
+  region  = var.region
+  version = "~> 2.50.0"
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/userpass/login/${var.vault_username}"
+
+    parameters = {
+      password = var.vault_password
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+module "hash_check" {
+  source = "./hash-check"
+
+  aws_account                           = var.aws_account
+  aws_account_id                        = data.aws_caller_identity.current.account_id
+  aws_profile                           = var.aws_profile
+  environment                           = var.environment
+  lambda_handler_name                   = var.lambda_handler_name
+  lambda_logs_retention_days            = var.lambda_logs_retention_days
+  lambda_memory_size                    = var.lambda_memory_size
+  lambda_runtime                        = var.lambda_runtime
+  lambda_timeout_seconds                = var.lambda_timeout_seconds
+  region                                = var.region
+  release_artifact_key                  = var.release_artifact_key
+  release_bucket_name                   = var.release_bucket_name
+  service                               = var.service
+}

--- a/groups/hash-check/main.tf
+++ b/groups/hash-check/main.tf
@@ -18,7 +18,6 @@ module "hash_check" {
   lambda_memory_size                    = var.lambda_memory_size
   lambda_runtime                        = var.lambda_runtime
   lambda_timeout_seconds                = var.lambda_timeout_seconds
-  region                                = var.region
   release_artifact_key                  = var.release_artifact_key
   release_bucket_name                   = var.release_bucket_name
   service                               = var.service

--- a/groups/hash-check/profiles/development-eu-west-2/harmon1/vars
+++ b/groups/hash-check/profiles/development-eu-west-2/harmon1/vars
@@ -1,0 +1,5 @@
+aws_profile = "development-eu-west-2"
+
+environment = "harmon1"
+
+lambda_timeout_seconds = 300

--- a/groups/hash-check/variables.tf
+++ b/groups/hash-check/variables.tf
@@ -64,23 +64,3 @@ variable "release_artifact_key" {
   type        = string
   description = "The release artifact key for the Lambda function"
 }
-
-variable "network_state_bucket_name" {
-  type        = string
-  description = "The name of the S3 bucket containing the application network remote state"
-}
-
-variable "network_state_bucket_key" {
-  type        = string
-  description = "The key name used when constructing the path to the application network remote state in the S3 bucket"
-}
-
-variable vault_username {
-  type        = string
-  description = "The HashiCorp Vault username used to retrieve secrets"
-}
-
-variable vault_password {
-  type        = string
-  description = "The HashiCorp Vault password used to retrieve secrets"
-}

--- a/groups/hash-check/variables.tf
+++ b/groups/hash-check/variables.tf
@@ -1,0 +1,86 @@
+variable "aws_account" {
+  type        = string
+  description = "The AWS account name"
+  default     = "development"
+}
+
+variable "aws_profile" {
+  type        = string
+  description = "The AWS profile name; used as a prefix for Vault secrets"
+}
+
+variable "region" {
+  type        = string
+  description = "The AWS region in which resources will be created"
+}
+
+variable "environment" {
+  type        = string
+  description = "The environment name to be used when creating AWS resources"
+}
+
+variable "service" {
+  type        = string
+  description = "The service name to be used when creating AWS resources"
+  default     = "bcrypt-hash-check"
+}
+
+variable "lambda_handler_name" {
+  type        = string
+  description = "The lambda function entrypoint"
+  default     = "uk.gov.companieshouse.bcrypthashcheck.Handler::handleRequest"
+}
+
+variable "lambda_logs_retention_days" {
+  type        = number
+  description = "The number of days to retain Lambda logs in CloudWatch"
+  default     = 7
+}
+
+variable "lambda_memory_size" {
+  type        = string
+  description = "The amount of memory made available to the Lambda function at runtime in megabytes"
+  default     = "4096"
+}
+
+variable "lambda_timeout_seconds" {
+  type        = string
+  description = "The amount of time the lambda function is allowed to run before being stopped"
+  default     = 600
+}
+
+variable "lambda_runtime" {
+  type        = string
+  description = "The lambda runtime to use for the function"
+  default     = "java8"
+}
+
+variable "release_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket containing the release artefact for the Lambda function"
+}
+
+variable "release_artifact_key" {
+  type        = string
+  description = "The release artifact key for the Lambda function"
+}
+
+variable "network_state_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket containing the application network remote state"
+}
+
+variable "network_state_bucket_key" {
+  type        = string
+  description = "The key name used when constructing the path to the application network remote state in the S3 bucket"
+}
+
+variable vault_username {
+  type        = string
+  description = "The HashiCorp Vault username used to retrieve secrets"
+}
+
+variable vault_password {
+  type        = string
+  description = "The HashiCorp Vault password used to retrieve secrets"
+}


### PR DESCRIPTION
This pr adds the initial code for the terraform infrastructure for the bcrypt hash check lambda. This code will create three resources, one for the lambda function, and an additional two for the iam role and the logs access. Currently harmon1 has been added as an initial test environment to work with.

**Resolves:**
- IDAM-518