### PR TITLE
add depends to integration response so integration is built first

### DIFF
--- a/groups/hash-check/hash-check/gateway.tf
+++ b/groups/hash-check/hash-check/gateway.tf
@@ -41,6 +41,9 @@ resource "aws_api_gateway_method_response" "response_200" {
 }
 
 resource "aws_api_gateway_integration_response" "hash_check_integration_response" {
+  depends_on = [
+    aws_api_gateway_integration.integration
+  ]
   rest_api_id = aws_api_gateway_rest_api.hash_check.id
   resource_id = aws_api_gateway_resource.hash_check_resource.id
   http_method = aws_api_gateway_method.hash_check_method.http_method


### PR DESCRIPTION
This PR adds a depends_on check to the build of integration_response so that the integration always builds first.

